### PR TITLE
Update deps and xacros

### DIFF
--- a/piper_bringup/package.xml
+++ b/piper_bringup/package.xml
@@ -15,7 +15,7 @@
   <exec_depend>joint_trajectory_controller</exec_depend>
   <exec_depend>parallel_gripper_controller</exec_depend>
   <exec_depend>rviz2</exec_depend>
-  <exec_depend>topic_based_ros2_control</exec_depend>
+  <exec_depend>joint_state_topic_hardware_interface</exec_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/piper_description/urdf/piper.ros2_control.xacro
+++ b/piper_description/urdf/piper.ros2_control.xacro
@@ -8,9 +8,9 @@
     mock_hardware:=false
     fake_sensor_commands:=false
     sim_gazebo:=false
-    sim_isaac:=false
-    isaac_joint_commands:=/isaac_joint_commands
-    isaac_joint_states:=/isaac_joint_states
+    joint_state_topic_hardware:=false
+    joint_commands_topic:=/joint_commands_topic
+    joint_states_topic:=/joint_states_topic
     initial_positions:=${dict(joint_1=0.0,joint_2=0.0,joint_3=0.0,joint_4=0.0,joint_5=0.0,joint_6=0.0)}">
 
     <ros2_control name="${name}" type="system">
@@ -18,21 +18,17 @@
         <xacro:if value="${sim_gazebo}">
           <plugin>gz_ros2_control/GazeboSimSystem</plugin>
         </xacro:if>
-        <xacro:if value="${sim_isaac}">
+        <!-- This supports Isaac sim and Hardware -->
+        <xacro:if value="${joint_state_topic_hardware}">
           <plugin>joint_state_topic_hardware_interface/JointStateTopicSystem</plugin>
-          <param name="joint_commands_topic">${isaac_joint_commands}</param>
-          <param name="joint_states_topic">${isaac_joint_states}</param>
+          <param name="joint_commands_topic">${joint_commands_topic}</param>
+          <param name="joint_states_topic">${joint_states_topic}</param>
         </xacro:if>
         <xacro:if value="${mock_hardware}">
           <plugin>mock_components/GenericSystem</plugin>
           <param name="fake_sensor_commands">${fake_sensor_commands}</param>
           <param name="state_following_offset">0.0</param>
         </xacro:if>
-        <xacro:unless value="${mock_hardware or sim_gazebo or sim_isaac}">
-          <plugin>joint_state_topic_hardware_interface/JointStateTopicSystem</plugin>
-          <param name="joint_commands_topic">/joint_ctrl_single</param>
-          <param name="joint_states_topic">/joint_states_single</param>
-        </xacro:unless>
       </hardware>
 
       <joint name="${prefix}joint_1">

--- a/piper_description/urdf/piper.ros2_control.xacro
+++ b/piper_description/urdf/piper.ros2_control.xacro
@@ -19,7 +19,7 @@
           <plugin>gz_ros2_control/GazeboSimSystem</plugin>
         </xacro:if>
         <xacro:if value="${sim_isaac}">
-          <plugin>topic_based_ros2_control/TopicBasedSystem</plugin>
+          <plugin>joint_state_topic_hardware_interface/JointStateTopicSystem</plugin>
           <param name="joint_commands_topic">${isaac_joint_commands}</param>
           <param name="joint_states_topic">${isaac_joint_states}</param>
         </xacro:if>
@@ -29,7 +29,7 @@
           <param name="state_following_offset">0.0</param>
         </xacro:if>
         <xacro:unless value="${mock_hardware or sim_gazebo or sim_isaac}">
-          <plugin>topic_based_ros2_control/TopicBasedSystem</plugin>
+          <plugin>joint_state_topic_hardware_interface/JointStateTopicSystem</plugin>
           <param name="joint_commands_topic">/joint_ctrl_single</param>
           <param name="joint_states_topic">/joint_states_single</param>
         </xacro:unless>

--- a/piper_description/urdf/piper.urdf.xacro
+++ b/piper_description/urdf/piper.urdf.xacro
@@ -4,7 +4,7 @@
     <!-- Arguments -->
     <xacro:arg name="prefix" default="" />
     <xacro:arg name="sim_gazebo" default="false" />
-    <xacro:arg name="sim_isaac" default="false" />
+    <xacro:arg name="joint_state_topic_hardware" default="false" />
     <xacro:arg name="mock_hardware" default="false" />
 
     <!-- Import macros for main hardware components -->
@@ -42,9 +42,9 @@
     <xacro:load_piper
         parent="table"
         prefix="$(arg prefix)"
+        joint_state_topic_hardware="$(arg joint_state_topic_hardware)"
         mock_hardware="$(arg mock_hardware)"
         sim_gazebo="$(arg sim_gazebo)"
-        sim_isaac="$(arg sim_isaac)"
         initial_positions="${xacro.load_yaml(initial_positions_file)}">
       <origin xyz="0 0 0" rpy="0 0 0" />  <!-- position robot in the world -->
     </xacro:load_piper>

--- a/piper_description/urdf/piper_macro.xacro
+++ b/piper_description/urdf/piper_macro.xacro
@@ -6,11 +6,11 @@
     prefix
     *origin
     include_gripper:=true
-    sim_isaac:=false
     sim_gazebo:=false
-    isaac_joint_commands:=/isaac_joint_commands
-    isaac_joint_states:=/isaac_joint_states
-    mock_hardware:=false
+    joint_commands_topic:=/joint_commands_topic
+    joint_states_topic:=/joint_states_topic
+    joint_state_topic_hardware:=false
+    mock_hardware:=true
     initial_positions:=${dict(joint_1=0.0,joint_2=0.0,joint_3=0.0,joint_4=0.0,joint_5=0.0,joint_6=0.0)}">
 
     <xacro:include filename="$(find piper_description)/urdf/piper_arm_macro.xacro" />
@@ -35,10 +35,10 @@
       name="${ros2_control_name}"
       prefix="${prefix}"
       include_gripper="${include_gripper}"
+      joint_state_topic_hardware="${joint_state_topic_hardware}"
       mock_hardware="${mock_hardware}"
-      sim_isaac="${sim_isaac}"
-      isaac_joint_commands="${isaac_joint_commands}"
-      isaac_joint_states="${isaac_joint_states}"
+      joint_commands_topic="${joint_commands_topic}"
+      joint_states_topic="${joint_states_topic}"
       sim_gazebo="${sim_gazebo}"
       initial_positions="${initial_positions}"/>
   </xacro:macro>

--- a/piper_moveit_config/package.xml
+++ b/piper_moveit_config/package.xml
@@ -19,13 +19,11 @@
   <exec_depend>moveit_simple_controller_manager</exec_depend>
   <exec_depend>moveit_ros_move_group</exec_depend>
   <exec_depend>moveit_ros_visualization</exec_depend>
-  <exec_depend>moveit_ros_warehouse</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>rviz2</exec_depend>
   <exec_depend>rviz_common</exec_depend>
   <exec_depend>rviz_default_plugins</exec_depend>
   <exec_depend>tf2_ros</exec_depend>
-  <exec_depend>warehouse_ros_mongo</exec_depend>
   <exec_depend>xacro</exec_depend>
 
   <export>


### PR DESCRIPTION
This PR updates the ros2_control hardware interface to use `joint_state_topic_hardware_interface/JointStateTopicSystem` and refactors the xacros to make it so Isaac or hardware can use that interface.